### PR TITLE
Set correct node limits

### DIFF
--- a/heroku_prep_ionic.js
+++ b/heroku_prep_ionic.js
@@ -41,7 +41,7 @@ package_file.dependencies["@angular-devkit/architect"] = package_file.devDepende
 package_file.dependencies["@angular-devkit/build-angular"] = package_file.devDependencies["@angular-devkit/build-angular"]
 package_file.dependencies["@angular-devkit/core"] = package_file.devDependencies["@angular-devkit/core"]
 package_file.dependencies["@angular-devkit/schematics"] = package_file.devDependencies["@angular-devkit/schematics"]
-package_file.dependencies["@angular/compiler"] = package_file.devDependencies["@angular/compiler"]
+// package_file.dependencies["@angular/compiler"] = package_file.devDependencies["@angular/compiler"]
 package_file.dependencies["@angular/language-service"] = package_file.devDependencies["@angular/language-service"]
 package_file.dependencies["@ionic/angular-toolkit"] = package_file.devDependencies["@ionic/angular-toolkit"] 
  

--- a/heroku_prep_ionic.js
+++ b/heroku_prep_ionic.js
@@ -47,7 +47,7 @@ package_file.dependencies["@ionic/angular-toolkit"] = package_file.devDependenci
  
     
 package_file.scripts["postinstall"] = "ng build --aot --prod";
-package_file["engines"] = {"node":"12.16.2", "npm":"6.13.4"};
+package_file["engines"] = {"node":"12.x", "npm":"6.x"};
 package_file.devDependencies["enhanced-resolve"]="4.1.1";
 package_file.dependencies["express"] = "^4.17.1";
 package_file.dependencies["path"] = "^0.12.7";


### PR DESCRIPTION
Newest patch for node 12.13 was not known by heroku, so changed to 12.x and npm to 6.x to ensure it keeps up to date with the LTS versions as they for node 12.

@angular/complier is situated in dependancies, so does not need to be linked to the devDependencies version.

